### PR TITLE
libcmis: Fix boost.m4 to avoid use of unsafe cross-compile paths

### DIFF
--- a/recipes-support/libcmis/files/0001-Avoid-cross-compile-unsafe-paths.patch
+++ b/recipes-support/libcmis/files/0001-Avoid-cross-compile-unsafe-paths.patch
@@ -1,0 +1,30 @@
+From 3c78f2d161550184b86e55a992b972fa136186d9 Mon Sep 17 00:00:00 2001
+From: Otavio Salvador <otavio@ossystems.com.br>
+Date: Tue, 19 Apr 2016 22:12:38 -0300
+Subject: [PATCH] Avoid cross-compile unsafe paths
+Organization: O.S. Systems Software LTDA.
+
+Upstream-Status: Inappropriate [embedded specific]
+
+Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>
+---
+ m4/boost.m4 | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/m4/boost.m4 b/m4/boost.m4
+index a4c366a..0b86299 100644
+--- a/m4/boost.m4
++++ b/m4/boost.m4
+@@ -440,8 +440,7 @@ for boost_rtopt_ in $boost_rtopt '' -d; do
+     boost_tmp_lib=$with_boost
+     test x"$with_boost" = x && boost_tmp_lib=${boost_cv_inc_path%/include}
+     for boost_ldpath in "$boost_tmp_lib/lib" '' \
+-             /opt/local/lib* /usr/local/lib* /opt/lib* /usr/lib* \
+-             "$with_boost" C:/Boost/lib /lib*
++             "$with_boost"
+     do
+       # Don't waste time with directories that don't exist.
+       if test x"$boost_ldpath" != x && test ! -e "$boost_ldpath"; then
+-- 
+2.1.4
+

--- a/recipes-support/libcmis/libcmis_0.5.1.bb
+++ b/recipes-support/libcmis/libcmis_0.5.1.bb
@@ -9,7 +9,9 @@ LIC_FILES_CHKSUM = " \
 
 SRC_URI = " \
     https://github.com/tdf/libcmis/releases/download/v${PV}/${BPN}-${PV}.tar.gz \
+    file://0001-Avoid-cross-compile-unsafe-paths.patch \
 "
+
 SRC_URI[md5sum] = "3270154f0f40d86fce849b161f914101"
 SRC_URI[sha256sum] = "6acbdf22ecdbaba37728729b75bfc085ee5a4b49a6024757cfb86ccd3da27b0e"
 


### PR DESCRIPTION
This fixes:

,----
| ERROR: libcmis-0.5.1-r0 do_configure: This autoconf log indicates
|     errors, it looked at host include and/or library paths while
|     determining system capabilities.  Rerun configure task after
|     fixing this.
`----

Signed-off-by: Otavio Salvador otavio@ossystems.com.br
