### PR TITLE
libreoffice: Remove non-existent configure option for mariadb.

### DIFF
--- a/recipes-libreoffice/libreoffice/libreoffice.bb
+++ b/recipes-libreoffice/libreoffice/libreoffice.bb
@@ -143,7 +143,7 @@ PACKAGECONFIG[gtk3] = "--enable-gtk3 , --disable-gtk3, gtk+3 cairo"
 PACKAGECONFIG[avahi] = "--enable-avahi, --disable-avahi, avahi"
 PACKAGECONFIG[odk] = "--enable-odk, --disable-odk"
 
-PACKAGECONFIG[mariadb] = "--with-system-mariadb, --disable-ext-mariadb-connector, mariadb"
+PACKAGECONFIG[mariadb] = "--with-system-mariadb, , mariadb"
 PACKAGECONFIG[postgresql] = "--enable-postgresql-sdbc --with-system-postgresql, --disable-postgresql-sdbc, postgresql"
 
 do_configure() {


### PR DESCRIPTION
This was removed from libreoffice in https://cgit.freedesktop.org/libreoffice/core/commit/?id=26b40fcfc67480e75bd9959b0c5cb9db10fdf6a1

Signed-off-by: Drew Moseley <drew.moseley@northern.tech>